### PR TITLE
(GH-81) Added VS-HelpLink and Links in message

### DIFF
--- a/src/Guidelines/build/CakeContrib.Guidelines.props
+++ b/src/Guidelines/build/CakeContrib.Guidelines.props
@@ -10,5 +10,13 @@
         <CakeContribGuidelinesCustomTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)/../tasks/net472/CakeContrib.Guidelines.Tasks.dll</CakeContribGuidelinesCustomTasksAssembly>
         <CakeContribGuidelinesCustomTasksNamespace>CakeContrib.Guidelines.Tasks</CakeContribGuidelinesCustomTasksNamespace>
     </PropertyGroup>
+
+    <UsingTask
+        TaskName="$(CakeContribGuidelinesCustomTasksNamespace).CcgLogError"
+        AssemblyFile="$(CakeContribGuidelinesCustomTasksAssembly)" />
+    <UsingTask
+        TaskName="$(CakeContribGuidelinesCustomTasksNamespace).CcgLogWarning"
+        AssemblyFile="$(CakeContribGuidelinesCustomTasksAssembly)" />
+
     <Import Project="$(MSBuildThisFileDirectory)Icon.props" />
 </Project>

--- a/src/Guidelines/build/Icon.targets
+++ b/src/Guidelines/build/Icon.targets
@@ -20,25 +20,25 @@
         <Message 
             Importance="low"
             Text="PackageIcon is set to $(PackageIcon)" />
-        <Error 
+        <CcgLogError
             Condition="$(PackageIcon) == ''"
-            Code="CCG0001" 
-            File="$(MSBuildProjectFullPath)" 
+            CcgId="1"
+            File="$(MSBuildProjectFullPath)"
             Text="PackageIcon is empty. Since you're using CakeContrib.Guidelines the PackageIcon should be set." />
-        <Warning
+        <CcgLogWarning
             Condition="$(PackageIcon) != '$(CakeContribGuidelinesIconDestinationLocation)'"
-            Code="CCG0003" 
-            File="$(MSBuildProjectFullPath)" 
+            CcgId="3"
+            File="$(MSBuildProjectFullPath)"
             Text="PackageIcon should point to $(CakeContribGuidelinesIconDestinationLocation)." />
         
         <!-- check PackageIconUrl -->
         <Message 
             Importance="low"
             Text="PackageIconUrl is set to $(PackageIconUrl)" />
-        <Warning 
+        <CcgLogWarning
             Condition="$(PackageIconUrl) == ''"
-            Code="CCG0002" 
-            File="$(MSBuildProjectFullPath)" 
+            CcgId="2"
+            File="$(MSBuildProjectFullPath)"
             Text="PackageIconUrl is empty. For compatibility it should be set." />
     </Target>
 </Project>

--- a/src/Tasks/CcgLogError.cs
+++ b/src/Tasks/CcgLogError.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+
+using CakeContrib.Guidelines.Tasks.Extensions;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace CakeContrib.Guidelines.Tasks
+{
+    /// <summary>
+    /// This is a convenience-Task to call CcgError from inside the msbuild.
+    /// </summary>
+    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Needed in Tasks")]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Needed in Tasks")]
+    [SuppressMessage("ReSharper", "UnusedType.Global", Justification = "Used as Task")]
+    public class CcgLogError : Task
+    {
+        /// <summary>
+        /// Gets or sets the CCG-Id.
+        /// </summary>
+        [Required]
+        public int CcgId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project file.
+        /// </summary>
+        public string File { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message text to be rendered.
+        /// </summary>
+        [Required]
+        public string Text { get; set; }
+
+        /// <inheritdoc />
+        public override bool Execute()
+        {
+            Log.CcgError(
+                CcgId,
+                File,
+                Text);
+
+            return false;
+        }
+    }
+}

--- a/src/Tasks/CcgLogWarning.cs
+++ b/src/Tasks/CcgLogWarning.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+
+using CakeContrib.Guidelines.Tasks.Extensions;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace CakeContrib.Guidelines.Tasks
+{
+    /// <summary>
+    /// This is a convenience-Task to call CcgWarning from inside the msbuild.
+    /// </summary>
+    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Needed in Tasks")]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Needed in Tasks")]
+    [SuppressMessage("ReSharper", "UnusedType.Global", Justification = "Used as Task")]
+    public class CcgLogWarning : Task
+    {
+        /// <summary>
+        /// Gets or sets the CCG-Id.
+        /// </summary>
+        [Required]
+        public int CcgId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project file.
+        /// </summary>
+        public string File { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message text to be rendered.
+        /// </summary>
+        [Required]
+        public string Text { get; set; }
+
+        /// <inheritdoc />
+        public override bool Execute()
+        {
+            Log.CcgWarning(
+                CcgId,
+                File,
+                Text);
+
+            return true;
+        }
+    }
+}

--- a/src/Tasks/CheckPrivateAssetsOnReferences.cs
+++ b/src/Tasks/CheckPrivateAssetsOnReferences.cs
@@ -1,5 +1,7 @@
 using System;
 
+using CakeContrib.Guidelines.Tasks.Extensions;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -44,15 +46,9 @@ namespace CakeContrib.Guidelines.Tasks
 
                     if (!privateAssets.Equals("all", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        Log.LogError(
-                            null,
-                            "CCG0004",
-                            string.Empty, // TODO: Can we get HelpLink like in roslyn analysers?
-                            ProjectFile ?? string.Empty,
-                            0,
-                            0,
-                            0,
-                            0,
+                        Log.CcgError(
+                            4,
+                            ProjectFile,
                             $"{pack} should have PrivateAssets=\"All\"");
                         return false;
                     }

--- a/src/Tasks/Extensions/LogExtensions.cs
+++ b/src/Tasks/Extensions/LogExtensions.cs
@@ -1,0 +1,80 @@
+﻿using System.Globalization;
+
+using Microsoft.Build.Utilities;
+
+namespace CakeContrib.Guidelines.Tasks.Extensions
+{
+    /// <summary>
+    /// Convenience methods for logging.
+    /// </summary>
+    internal static class LogExtensions
+    {
+        /// <summary>
+        /// Writes a warning.
+        /// This is a convenience-Method that wraps some always identical parameters.
+        /// </summary>
+        /// <param name="log">The <see cref="TaskLoggingHelper"/> instance.</param>
+        /// <param name="ccgRuleId">The CCG Rule.</param>
+        /// <param name="projectFile">The project file. May be null.</param>
+        /// <param name="message">The message to show.</param>
+        internal static void CcgWarning(this TaskLoggingHelper log, int ccgRuleId, string projectFile, string message)
+        {
+            var ccgRule = GetRule(ccgRuleId);
+            var helpLink = GetHelpLink(ccgRuleId);
+            message = $"{message} (see {helpLink})";
+
+            log.LogWarning(
+                null,
+                ccgRule,
+                string.Empty, // not usable anyway. See https://github.com/MicrosoftDocs/visualstudio-docs/issues/5894
+                helpLink,
+                projectFile ?? string.Empty,
+                0,
+                0,
+                0,
+                0,
+                message);
+        }
+
+        /// <summary>
+        /// Writes a warning.
+        /// This is a convenience-Method that wraps some always identical parameters.
+        /// </summary>
+        /// <param name="log">The <see cref="TaskLoggingHelper"/> instance.</param>
+        /// <param name="ccgRuleId">The CCG Rule.</param>
+        /// <param name="projectFile">The project file. May be null.</param>
+        /// <param name="message">The message to show.</param>
+        internal static void CcgError(this TaskLoggingHelper log, int ccgRuleId, string projectFile, string message)
+        {
+            var ccgRule = GetRule(ccgRuleId);
+            var helpLink = GetHelpLink(ccgRuleId);
+            message = $"{message} (see {helpLink})";
+
+            log.LogError(
+                null,
+                ccgRule,
+                string.Empty, // not usable anyway. See https://github.com/MicrosoftDocs/visualstudio-docs/issues/5894
+                helpLink,
+                projectFile ?? string.Empty,
+                0,
+                0,
+                0,
+                0,
+                message);
+        }
+
+        private static string GetRule(int ruleId)
+        {
+            return "CCG" + ruleId.ToString("D4", CultureInfo.InvariantCulture);
+        }
+
+        private static string GetHelpLink(int ruleId)
+        {
+            var ccgRule = GetRule(ruleId);
+
+#pragma warning disable CA1308
+            return $"https://cake-contrib.github.io/CakeContrib.Guidelines/rules/{ccgRule.ToLowerInvariant()}";
+#pragma warning restore CA1308
+        }
+    }
+}

--- a/src/Tasks/RequiredFileEditorconfig.cs
+++ b/src/Tasks/RequiredFileEditorconfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 
+using CakeContrib.Guidelines.Tasks.Extensions;
 using CakeContrib.Guidelines.Tasks.Testability;
 
 using Microsoft.Build.Framework;
@@ -57,15 +58,9 @@ namespace CakeContrib.Guidelines.Tasks
                 return true;
             }
 
-            Log.LogWarning(
-                null,
-                "CCG0006",
-                string.Empty, // TODO: Can we get HelpLink like in roslyn analysers?
+            Log.CcgWarning(
+                6,
                 ProjectFile,
-                0,
-                0,
-                0,
-                0,
                 $"No '{FileName}' found in folder-structure. Usage of '{FileName}' is strongly recommended.");
             return true;
         }

--- a/src/Tasks/RequiredFileStylecopJson.cs
+++ b/src/Tasks/RequiredFileStylecopJson.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 
+using CakeContrib.Guidelines.Tasks.Extensions;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -61,15 +63,9 @@ namespace CakeContrib.Guidelines.Tasks
                 }
             }
 
-            Log.LogWarning(
-                null,
-                "CCG0006",
-                string.Empty, // TODO: Can we get HelpLink like in roslyn analysers?
-                ProjectFile ?? string.Empty,
-                0,
-                0,
-                0,
-                0,
+            Log.CcgWarning(
+                6,
+                ProjectFile,
                 $"No reference to '{SettingsFileName}' found. Usage of '{SettingsFileName}' is strongly recommended.");
 
             return true;

--- a/src/Tasks/RequiredReferences.cs
+++ b/src/Tasks/RequiredReferences.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 
+using CakeContrib.Guidelines.Tasks.Extensions;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -52,15 +54,9 @@ namespace CakeContrib.Guidelines.Tasks
                     continue;
                 }
 
-                Log.LogWarning(
-                    null,
-                    "CCG0005",
-                    string.Empty, // TODO: Can we get HelpLink like in roslyn analysers?
-                    ProjectFile ?? string.Empty,
-                    0,
-                    0,
-                    0,
-                    0,
+                Log.CcgWarning(
+                    5,
+                    ProjectFile,
                     $"No reference to '{r}' found. Usage of '{r}' is strongly recommended");
             }
 

--- a/src/Tasks/TargetFrameworkVersions.cs
+++ b/src/Tasks/TargetFrameworkVersions.cs
@@ -83,7 +83,9 @@ namespace CakeContrib.Guidelines.Tasks
 
             if (!Version.TryParse(cakeCore.GetMetadata("version"), out Version version))
             {
-                Log.LogWarning(
+                Log.CcgWarning(
+                    7,
+                    ProjectFile,
                     $"Cake.Core has a version of {cakeCore.GetMetadata("version")} which is not a valid version. Using default TargetVersions.");
                 return Execute(DefaultTarget);
             }
@@ -144,15 +146,9 @@ namespace CakeContrib.Guidelines.Tasks
                     continue;
                 }
 
-                Log.LogError(
-                    null,
-                    "CCG0007",
-                    string.Empty,
-                    ProjectFile ?? string.Empty,
-                    0,
-                    0,
-                    0,
-                    0,
+                Log.CcgError(
+                    7,
+                    ProjectFile,
                     "Missing required target: " + requiredTarget.Name);
                 return false;
             }
@@ -181,15 +177,9 @@ namespace CakeContrib.Guidelines.Tasks
                     continue;
                 }
 
-                Log.LogWarning(
-                    null,
-                    "CCG0007",
-                    string.Empty,
-                    ProjectFile ?? string.Empty,
-                    0,
-                    0,
-                    0,
-                    0,
+                Log.CcgWarning(
+                    7,
+                    ProjectFile,
                     "Missing suggested target: " + suggestedTarget.Name);
             }
 


### PR DESCRIPTION
since the update of Microsoft.Build.Utilities.Core to v16.8.0
it is possible to add a HelpLink to errors and warnings
so in Visual Studio (beginning with 16.8) clickable links
will be rendered in the error pane.

Additionally for non VS users (or users of older VS)
the link is added to the output of the message.

In VS *Error List* the output is like this:
![image](https://user-images.githubusercontent.com/349188/108273146-7602ba00-7173-11eb-91f3-71eb15e3bd50.png)
and the Link on the left leads to the desired page (I have tested only VS 16.8.5 - I guess versions before 16.8 will not do so)

While in the console (and Rider) it looks like this:
![image](https://user-images.githubusercontent.com/349188/108273384-c67a1780-7173-11eb-8596-8217be796541.png)
Here, link in the text can be clickable, if the console in use allows for it. 

fixes #81 