### PR TITLE
(#156) downgraded msbuild references to 16.8.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,13 @@
   "extends": [ "github>nils-a/renovate-config" ],
   "packageRules": [
     {
-      "matchPackageNames": ["cake.tool", "Cake.Core"],
+      "matchPackageNames": [
+        "cake.tool",
+        "Cake.Core",
+        "Microsoft.Build",
+        "Microsoft.Build.Framework",
+        "Microsoft.Build.Utilities.Core"
+      ],
       "enabled": false
     }
   ]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ or add the `PackageReference` manually
 
 See [NuGet](https://www.nuget.org/packages/CakeContrib.Guidelines/) for the current version.
 
+CakeContrib.Guidelines requires the use of `msbuild` version 16.8.0 or later.
+
 ## Guidelines
 
 All [guidelines](https://cake-contrib.github.io/CakeContrib.Guidelines/guidelines) and [rules](https://cake-contrib.github.io/CakeContrib.Guidelines/rules) are documented at <https://cake-contrib.github.io/CakeContrib.Guidelines/>

--- a/docs/input/index.cshtml
+++ b/docs/input/index.cshtml
@@ -17,12 +17,21 @@ NoGutter: true
 
 <div class="container text-center">
     <div class="row slideanim">
-        <div class="col-sm-4">
+        <div class="col-xs-8 col-xs-offset-2 col-md-6 col-md-offset-3">
             <span class="glyphicon glyphicon-heart logo-small"></span>
             <h3 class="no-anchor">Open-Source</h3>
             <p>
                 CakeContrib.Guidelines is free to use, improve, contribute and distribute.
                 Source code is available on <a href="https://github.com/cake-contrib/CakeContrib.Guidelines">GitHub</a> under MIT license.
+            </p>
+        </div>
+    </div>
+    <div class="row slideanim">
+        <div class="col-xs-8 col-xs-offset-2 col-md-6 col-md-offset-3">
+            <span class="glyphicon glyphicon-wrench logo-small"></span>
+            <h3 class="no-anchor">Prerequisites</h3>
+            <p>
+                Using CakeContrib.Guidelines requires msbuild version 16.8.0 or later.
             </p>
         </div>
     </div>

--- a/src/Guidelines/build/CakeContrib.Guidelines.targets
+++ b/src/Guidelines/build/CakeContrib.Guidelines.targets
@@ -41,4 +41,11 @@
         </CreateProperty>
     </Target>
 
+    <Target Name="EnsureCorrectMsBuildVersion">
+        <PropertyGroup>
+            <RequiredMinimumVersion>16.8.0</RequiredMinimumVersion>
+        </PropertyGroup>
+        <Error Condition="$(MSBuildVersion) &lt; $(RequiredMinimumVersion)"
+               Text='CakeContrib.Guidelines needs at least MSBuild version $(RequiredMinimumVersion). (Current version: $(MSBuildVersion))' />
+    </Target>
 </Project>

--- a/src/Guidelines/build/Icon.targets
+++ b/src/Guidelines/build/Icon.targets
@@ -11,7 +11,7 @@
     <Target Name="_EnsureCakeContribGuidelinesIcon"
             AfterTargets="BeforeBuild"
             BeforeTargets="CoreBuild;SetNuspecProperties;GenerateNuspec;_GetPackageFiles"
-            DependsOnTargets="EnsureProjectTypeIsSet">
+            DependsOnTargets="EnsureProjectTypeIsSet;EnsureCorrectMsBuildVersion">
         <PropertyGroup>
             <CakeContribIconPath>$(MSBuildThisFileDirectory)/../images/cake-contrib-community-medium.png</CakeContribIconPath>
             <CakeContribIconPath

--- a/src/Guidelines/build/PrivateAssets.targets
+++ b/src/Guidelines/build/PrivateAssets.targets
@@ -8,7 +8,8 @@
     <Target
         Name="_CheckPrivateAssets"
         AfterTargets="BeforeBuild"
-        BeforeTargets="CoreBuild">
+        BeforeTargets="CoreBuild"
+        DependsOnTargets="EnsureCorrectMsBuildVersion">
         <ItemGroup>
             <CakeContribGuidelinesPrivateReference Include="Cake.Core" />
             <CakeContribGuidelinesPrivateReference Include="Cake.Common" />

--- a/src/Guidelines/build/RecommendedCakeVersion.targets
+++ b/src/Guidelines/build/RecommendedCakeVersion.targets
@@ -8,7 +8,7 @@
     <Target Name="_checkRecommendedCakeVersion"
             AfterTargets="BeforeBuild"
             BeforeTargets="CoreBuild"
-            DependsOnTargets="EnsureProjectTypeIsSet">
+            DependsOnTargets="EnsureProjectTypeIsSet;EnsureCorrectMsBuildVersion">
         <ItemGroup>
             <CakeReferenceToCheck Include="cake.core" />
             <CakeReferenceToCheck Include="cake.common" />

--- a/src/Guidelines/build/RecommendedTags.targets
+++ b/src/Guidelines/build/RecommendedTags.targets
@@ -8,7 +8,7 @@
     <Target Name="_checkRecommendedTags"
             AfterTargets="BeforeBuild"
             BeforeTargets="CoreBuild"
-            DependsOnTargets="EnsureProjectTypeIsSet"
+            DependsOnTargets="EnsureProjectTypeIsSet;EnsureCorrectMsBuildVersion"
             Condition="$(IsPackable) != 'false'">
         <ItemGroup>
             <RecommendedTag Include="cake" />

--- a/src/Guidelines/build/RequiredFiles.targets
+++ b/src/Guidelines/build/RequiredFiles.targets
@@ -12,7 +12,7 @@
         Name="_CheckRequiredFiles"
         AfterTargets="BeforeBuild"
         BeforeTargets="CoreBuild"
-        DependsOnTargets="EnsureProjectTypeIsSet">
+        DependsOnTargets="EnsureProjectTypeIsSet;EnsureCorrectMsBuildVersion">
 
         <RequiredFileEditorconfig
             OmitFiles="@(CakeContribGuidelinesOmitRecommendedConfigFile)"

--- a/src/Guidelines/build/RequiredReferences.targets
+++ b/src/Guidelines/build/RequiredReferences.targets
@@ -9,7 +9,7 @@
         Name="_CheckRequiredReferences"
         AfterTargets="BeforeBuild"
         BeforeTargets="CoreBuild"
-        DependsOnTargets="EnsureProjectTypeIsSet">
+        DependsOnTargets="EnsureProjectTypeIsSet;EnsureCorrectMsBuildVersion">
         <ItemGroup>
             <CakeContribGuidelinesRequiredReference Include="StyleCop.Analyzers" />
         </ItemGroup>

--- a/src/Guidelines/build/TargetFrameworkVersions.targets
+++ b/src/Guidelines/build/TargetFrameworkVersions.targets
@@ -9,7 +9,7 @@
         Name="_CheckTargetFrameworkVersions"
         AfterTargets="BeforeBuild"
         BeforeTargets="CoreBuild"
-        DependsOnTargets="EnsureProjectTypeIsSet">
+        DependsOnTargets="EnsureProjectTypeIsSet;EnsureCorrectMsBuildVersion">
 
         <!-- All other rules have some "configuration" here, this rules required/suggested targets are hard-coded in the task. Sadly. -->
 

--- a/src/Tasks.IntegrationTests/E2eTests.cs
+++ b/src/Tasks.IntegrationTests/E2eTests.cs
@@ -312,7 +312,7 @@ namespace CakeContrib.Guidelines.Tasks.IntegrationTests
             var output = result.WarningLines
                 .First(x => x.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase) > -1);
             output = output.Substring(output.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase)+11);
-            output.ShouldBeEquivalentTo("Addin");
+            output.ShouldBe("Addin", StringCompareShould.IgnoreCase);
         }
 
         [Fact]
@@ -365,7 +365,7 @@ namespace CakeContrib.Guidelines.Tasks.IntegrationTests
             var output = result.WarningLines
                 .First(x => x.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase) > -1);
             output = output.Substring(output.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase)+11);
-            output.ShouldBeEquivalentTo("Module");
+            output.ShouldBe("Module", StringCompareShould.IgnoreCase);
         }
 
         [Fact]
@@ -393,7 +393,7 @@ namespace CakeContrib.Guidelines.Tasks.IntegrationTests
             var output = result.WarningLines
                 .First(x => x.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase) > -1);
             output = output.Substring(output.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase)+11);
-            output.ShouldBeEquivalentTo("Module");
+            output.ShouldBe("Module", StringCompareShould.IgnoreCase);
         }
 
         [Fact]
@@ -418,7 +418,7 @@ namespace CakeContrib.Guidelines.Tasks.IntegrationTests
             var output = result.WarningLines
                 .First(x => x.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase) > -1);
             output = output.Substring(output.IndexOf("!FOR-TEST!:", StringComparison.OrdinalIgnoreCase)+11);
-            output.ShouldBeEquivalentTo("Addin");
+            output.ShouldBe("Addin", StringCompareShould.IgnoreCase);
         }
 
         [Fact]
@@ -698,7 +698,7 @@ namespace CakeContrib.Guidelines.Tasks.IntegrationTests
             var result = fixture.Run();
 
             // then
-            result.IsErrorExitCode.ShouldBeFalse();
+            result.IsErrorExitCode.ShouldBeTrue();
             result.WarningLines.ShouldNotContain(l => l.IndexOf("CCG0007", StringComparison.Ordinal) > -1);
             result.ErrorLines.ShouldContain(l => l.IndexOf("CCG0007", StringComparison.Ordinal) > -1);
         }

--- a/src/Tasks.IntegrationTests/Tasks.IntegrationTests.csproj
+++ b/src/Tasks.IntegrationTests/Tasks.IntegrationTests.csproj
@@ -39,9 +39,9 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Build" Version="16.11.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="16.11.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build" Version="16.8.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tasks.Tests/Tasks.Tests.csproj
+++ b/src/Tasks.Tests/Tasks.Tests.csproj
@@ -39,9 +39,9 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Build" Version="16.11.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="16.11.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build" Version="16.8.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tasks/Tasks.csproj
+++ b/src/Tasks/Tasks.csproj
@@ -15,8 +15,12 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" CopyLocal="false" Publish="false" ExcludeAssets="runtime" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="16.11.0" CopyLocal="false" Publish="false" ExcludeAssets="runtime" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" CopyLocal="false" Publish="false" ExcludeAssets="runtime" PrivateAssets="all">
+          <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" CopyLocal="false" Publish="false" ExcludeAssets="runtime" PrivateAssets="all">
+          <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
And added some documentation that msbuild >= 16.8.0 is required.

Also, added a check for the required version. 
If msbuild is a version < 1.8.0 the build will fail and show an error:
> ...\...\CakeContrib.Guidelines.targets(48,9): error : CakeContrib.Guidelines needs at least MSBuild version 16.8.0. (Current version: 16.7.0) 