### PR TITLE
(#175) added CakeContribGuidelinesOverrideTargetFrameworkCakeVersion

### DIFF
--- a/src/Guidelines/build/TargetFrameworkVersions.targets
+++ b/src/Guidelines/build/TargetFrameworkVersions.targets
@@ -20,6 +20,7 @@
             TargetFrameworks="$(TargetFrameworks)"
             Omitted="@(CakeContribGuidelinesOmitTargetFramework)"
             ProjectType="$(CakeContribGuidelinesProjectType)"
+            CakeVersion="$(CakeContribGuidelinesOverrideTargetFrameworkCakeVersion)"
             NoWarn="$(NoWarn)"
             WarningsAsErrors="$(WarningsAsErrors)" />
     </Target>

--- a/src/Tasks.IntegrationTests/E2eTests.cs
+++ b/src/Tasks.IntegrationTests/E2eTests.cs
@@ -706,5 +706,26 @@ namespace CakeContrib.Guidelines.Tasks.IntegrationTests
             result.ErrorLines.ShouldContain(l => l.IndexOf("CCG0007", StringComparison.Ordinal) > -1);
         }
 
+        [Fact]
+        public void Missing_Required_Target_results_in_CCG0007_error_if_Cake_Version_Is_Set_Explicitly()
+        {
+            // given
+            fixture.WithTargetFrameworks("net5.0");
+            fixture.WithoutDefaultCakeReference();
+            fixture.WithCustomContent(@"
+<PropertyGroup>
+  <CakeContribGuidelinesProjectType>module</CakeContribGuidelinesProjectType>
+  <CakeContribGuidelinesOverrideTargetFrameworkCakeVersion>1.2.3</CakeContribGuidelinesOverrideTargetFrameworkCakeVersion>
+</PropertyGroup>");
+
+            // when
+            var result = fixture.Run();
+
+            // then
+            result.IsErrorExitCode.ShouldBeTrue();
+            var err = result.ErrorLines.FirstOrDefault(l => l.IndexOf("CCG0007", StringComparison.Ordinal) > -1);
+            err.ShouldNotBeNull();
+            err.ShouldContain("netstandard2.0");
+        }
     }
 }

--- a/src/Tasks.Tests/Fixtures/TargetFrameworkVersionsFixture.cs
+++ b/src/Tasks.Tests/Fixtures/TargetFrameworkVersionsFixture.cs
@@ -73,6 +73,11 @@ namespace CakeContrib.Guidelines.Tasks.Tests.Fixtures
             Task.ProjectType = projectType;
         }
 
+        public void WithExplicitCakeVersion(string version)
+        {
+            Task.CakeVersion = version;
+        }
+
         public void WithProjectFile(string fileName)
         {
             Task.ProjectFile = fileName;

--- a/src/Tasks.Tests/TargetFrameworkVersionsTests.cs
+++ b/src/Tasks.Tests/TargetFrameworkVersionsTests.cs
@@ -309,5 +309,21 @@ namespace CakeContrib.Guidelines.Tasks.Tests
             fixture.BuildEngine.ErrorEvents.Count.ShouldBe(1);
             fixture.BuildEngine.ErrorEvents.First().Message.ShouldContain(NetCore31);
         }
+
+        [Fact]
+        public void Should_Error_If_RequiredTargetFramework_Is_Not_Targeted_Module_Explicit_Version()
+        {
+            // given
+            var fixture = new TargetFrameworkVersionsFixture();
+            fixture.WithProjectType("module");
+            fixture.WithExplicitCakeVersion("1.0.0");
+
+            // when
+            fixture.Execute();
+
+            // then
+            fixture.BuildEngine.ErrorEvents.Count.ShouldBe(1);
+            fixture.BuildEngine.ErrorEvents.First().Message.ShouldContain(NetStandard20);
+        }
     }
 }


### PR DESCRIPTION
to override auto-detection of Cake version for TargetFrameworkVersion-rules

closes #175 