### PR TITLE
Updated TargetFrameworkVersions to match Cake 3.0.0 versions.

### DIFF
--- a/docs/input/guidelines/RecommendedCakeVersion.md
+++ b/docs/input/guidelines/RecommendedCakeVersion.md
@@ -17,7 +17,8 @@ Title: Recommended Cake Version
 ## Goals
 
 For addins and modules it is recommended to reference the lowest version of Cake with API compatibility to the latest version.
-This is currently version 1.0.0.
+
+This is currently version 3.0.0.
 
 ## Related rules
 

--- a/docs/input/guidelines/TargetFramework.md
+++ b/docs/input/guidelines/TargetFramework.md
@@ -36,8 +36,20 @@ while missing a suggested target version will raise [CCG0007](../rules/ccg0007) 
     * Suggested: `net461`
       * alternative: `net46`
     * Suggested: `net5.0`
+  * Cake.Core >= 2.0.0
+    * Required: `netcoreapp3.1`
+    * Required: `net5.0`
+    * Required: `net6.0`
+  * Cake.Core >= 3.0.0
+    * Required: `net6.0`
+    * Required: `net7.0`
 * Package type: module
-  * Required: `netstandard2.0`
+  * Cake.Core < 2.0.0
+    * Required: `netstandard2.0`
+  * Cake.Core >= 2.0.0
+    * Required: `netcoreapp3.1`
+  * Cake.Core >= 3.0.0
+    * Required: `net6.0`
 
 For package type recipe no framework reference is required or suggested.
 

--- a/docs/input/rules/ccg0009.md
+++ b/docs/input/rules/ccg0009.md
@@ -41,4 +41,4 @@ Reference the recommended version of Cake:
 
 ## Related guidelines
 
-* [Recommended Tags](../guidelines/RecommendedCakeVersion)
+* [Recommended Cake Version](../guidelines/RecommendedCakeVersion)

--- a/src/Guidelines/build/RecommendedCakeVersion.targets
+++ b/src/Guidelines/build/RecommendedCakeVersion.targets
@@ -15,7 +15,7 @@
             <CakeReferenceToCheck Include="cake.testing" />
         </ItemGroup>
         <PropertyGroup>
-            <RecommendedCakeVersion>2.0.0</RecommendedCakeVersion>
+            <RecommendedCakeVersion>3.0.0</RecommendedCakeVersion>
         </PropertyGroup>
 
         <RecommendedCakeVersion

--- a/src/Tasks.Tests/Fixtures/TargetFrameworkVersionsFixture.cs
+++ b/src/Tasks.Tests/Fixtures/TargetFrameworkVersionsFixture.cs
@@ -41,7 +41,7 @@ namespace CakeContrib.Guidelines.Tasks.Tests.Fixtures
         public void WithTargetFrameworksMatchingDefault()
         {
             targetFrameworks.Clear();
-            WithTargetFrameworks("netcoreapp3.1", "net5.0", "net6.0"); // matches the "Default" of CakeContrib.Guidelines.Tasks.TargetFrameworkVersions
+            WithTargetFrameworks("net6.0", "net7.0"); // matches the "Default" of CakeContrib.Guidelines.Tasks.TargetFrameworkVersions
         }
 
         public void WithTargetFrameworks(params string[] packageNames)

--- a/src/Tasks/TargetFrameworkVersions.cs
+++ b/src/Tasks/TargetFrameworkVersions.cs
@@ -27,19 +27,20 @@ namespace CakeContrib.Guidelines.Tasks
         private const string NetCore31 = "netcoreapp3.1";
         private const string Net50 = "net5.0";
         private const string Net60 = "net6.0";
+        private const string Net70 = "net7.0";
 
         private static readonly Version Vo26 = new Version(0, 26, 0);
         private static readonly Version V1 = new Version(1, 0, 0);
         private static readonly Version V2 = new Version(2, 0, 0);
+        private static readonly Version V3 = new Version(3, 0, 0);
 
         private static readonly TargetsDefinitions DefaultTarget = new TargetsDefinitions
         {
             Name = "Default",
             RequiredTargets = new[]
             {
-                TargetsDefinition.From(NetCore31),
-                TargetsDefinition.From(Net50),
                 TargetsDefinition.From(Net60),
+                TargetsDefinition.From(Net70),
             },
             SuggestedTargets = Array.Empty<TargetsDefinition>(),
         };
@@ -56,11 +57,19 @@ namespace CakeContrib.Guidelines.Tasks
                     }
                 },
                 {
-                    d => d.IsModuleProject && d.Version.GreaterEqual(V2),
+                    d => d.IsModuleProject && d.Version.GreaterEqual(V2) && d.Version.LessThan(V3),
                     new TargetsDefinitions
                     {
                         Name = "Module",
                         RequiredTargets = new[] { TargetsDefinition.From(NetCore31) },
+                    }
+                },
+                {
+                    d => d.IsModuleProject && d.Version.GreaterEqual(V3),
+                    new TargetsDefinitions
+                    {
+                        Name = "Module",
+                        RequiredTargets = new[] { TargetsDefinition.From(Net60) },
                     }
                 },
                 {
@@ -86,15 +95,28 @@ namespace CakeContrib.Guidelines.Tasks
                     }
                 },
                 {
-                    d => !d.IsModuleProject && d.Version.GreaterEqual(V2),
+                    d => !d.IsModuleProject && d.Version.GreaterEqual(V2) && d.Version.LessThan(V3),
                     new TargetsDefinitions
                     {
-                        Name = "x >= 2.0.0",
+                        Name = "2.0.0 <= x < 3.0.0",
                         RequiredTargets = new[]
                         {
                             TargetsDefinition.From(NetCore31),
                             TargetsDefinition.From(Net50),
                             TargetsDefinition.From(Net60),
+                        },
+                        SuggestedTargets = Array.Empty<TargetsDefinition>(),
+                    }
+                },
+                {
+                    d => !d.IsModuleProject && d.Version.GreaterEqual(V3),
+                    new TargetsDefinitions
+                    {
+                        Name = "x >= 3.0.0",
+                        RequiredTargets = new[]
+                        {
+                            TargetsDefinition.From(Net60),
+                            TargetsDefinition.From(Net70),
                         },
                         SuggestedTargets = Array.Empty<TargetsDefinition>(),
                     }


### PR DESCRIPTION
As noted in #217, the supported frameworks needs to be updated following the release of Cake 3.0.0.

As best as I can tell, this is what was necessary to change - and local tests at least work with the version produced with my changes. I'm very much open to feedback on this, should I have missed/misunderstood something.