### PR TITLE
Revert new VSCode generated TOCs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "powershell.codeFormatting.addWhitespaceAroundPipe": true
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "markdown.extension.toc.updateOnSave": false
 }

--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ Adds common guidelines to cake-contrib projects
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [CakeContrib.Guidelines](#cakecontribguidelines)
-  - [Table of Contents](#table-of-contents)
-  - [Install](#install)
-  - [Guidelines](#guidelines)
-  - [Discussion](#discussion)
-  - [Maintainer](#maintainer)
-  - [Contributing](#contributing)
-    - [Contributors](#contributors)
-  - [License](#license)
+- [Install](#install)
+- [Guidelines](#guidelines)
+- [Discussion](#discussion)
+- [Maintainer](#maintainer)
+- [Contributing](#contributing)
+  - [Contributors](#contributors)
+- [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docs/input/guidelines/CakeContribIcon.md
+++ b/docs/input/guidelines/CakeContribIcon.md
@@ -6,7 +6,6 @@ Title: CakeContrib-Icon
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Goals](#goals)
 - [Related rules](#related-rules)
 - [Usage](#usage)

--- a/docs/input/guidelines/CakeInternalReferences.md
+++ b/docs/input/guidelines/CakeInternalReferences.md
@@ -8,6 +8,9 @@ Title: Target Frameworks
 
 - [Goals](#goals)
   - [Provided packages](#provided-packages)
+    - [Cake v1.0](#cake-v10)
+    - [Cake v2.0.0](#cake-v200)
+    - [Cake v3.0.0](#cake-v300)
 - [Related rules](#related-rules)
 - [Usage](#usage)
 

--- a/docs/input/guidelines/PrivateAssets.md
+++ b/docs/input/guidelines/PrivateAssets.md
@@ -6,7 +6,6 @@ Title: PrivateAssets in references
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Goals](#goals)
 - [Related rules](#related-rules)
 - [Usage](#usage)

--- a/docs/input/guidelines/RecommendedCakeVersion.md
+++ b/docs/input/guidelines/RecommendedCakeVersion.md
@@ -6,7 +6,6 @@ Title: Recommended Cake Version
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Goals](#goals)
 - [Related rules](#related-rules)
 - [Usage](#usage)

--- a/docs/input/guidelines/RecommendedReferences.md
+++ b/docs/input/guidelines/RecommendedReferences.md
@@ -6,7 +6,6 @@ Title: Recommended References
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Goals](#goals)
 - [Related rules](#related-rules)
 - [Usage](#usage)

--- a/docs/input/guidelines/RecommendedTags.md
+++ b/docs/input/guidelines/RecommendedTags.md
@@ -6,7 +6,6 @@ Title: Recommended Tags
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Goals](#goals)
   - [Recommended tags](#recommended-tags)
   - [Tag delimiter](#tag-delimiter)

--- a/docs/input/guidelines/TargetFramework.md
+++ b/docs/input/guidelines/TargetFramework.md
@@ -6,7 +6,6 @@ Title: Target Frameworks
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Goals](#goals)
   - [Required / Suggested versions](#required--suggested-versions)
 - [Related rules](#related-rules)

--- a/docs/input/guidelines/examples/Editorconfig.md
+++ b/docs/input/guidelines/examples/Editorconfig.md
@@ -7,7 +7,6 @@ Title: Example for .editorconfig
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Example](#example)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/docs/input/guidelines/examples/StyleCopJson.md
+++ b/docs/input/guidelines/examples/StyleCopJson.md
@@ -7,7 +7,6 @@ Title: Example for stylecop.json
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Example](#example)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/docs/input/rules/ccg0001.md
+++ b/docs/input/rules/ccg0001.md
@@ -10,7 +10,6 @@ Description:  PackageIcon is empty
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0002.md
+++ b/docs/input/rules/ccg0002.md
@@ -10,7 +10,6 @@ Description:  PackageIconUrl is empty
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0003.md
+++ b/docs/input/rules/ccg0003.md
@@ -10,7 +10,6 @@ Description:  PackageIcon can not be updated
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0004.md
+++ b/docs/input/rules/ccg0004.md
@@ -10,7 +10,6 @@ Description: Cake-reference has not set `PrivateAssets="all"`
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0005.md
+++ b/docs/input/rules/ccg0005.md
@@ -10,7 +10,6 @@ Description: Usage of analysers is recommended
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0006.md
+++ b/docs/input/rules/ccg0006.md
@@ -10,7 +10,6 @@ Description: Missing recommended configuraion-file
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0007.md
+++ b/docs/input/rules/ccg0007.md
@@ -10,7 +10,6 @@ Description: Missing recommended target
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0008.md
+++ b/docs/input/rules/ccg0008.md
@@ -12,7 +12,6 @@ Description: Missing recommended tag
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/rules/ccg0009.md
+++ b/docs/input/rules/ccg0009.md
@@ -10,7 +10,6 @@ Description: Referenced Cake version is not recommended
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Cause](#cause)
 - [Description](#description)
 - [How to fix violations](#how-to-fix-violations)

--- a/docs/input/settings/index.md
+++ b/docs/input/settings/index.md
@@ -8,7 +8,6 @@ NoSidebar: true
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [General](#general)
   - [ProjectType](#projecttype)
   - [Cake version](#cake-version)
@@ -21,6 +20,8 @@ NoSidebar: true
   - [OmitRecommendedTag](#omitrecommendedtag)
   - [OmitPrivateCheck](#omitprivatecheck)
   - [OmitTargetFramework](#omittargetframework)
+- [Override](#override)
+  - [OverrideTargetFrameworkCakeVersion](#overridetargetframeworkcakeversion)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
This reverts the changes done in https://github.com/cake-contrib/CakeContrib.Guidelines/commit/e3ddff98fa8bed6683a163363385f8d7353406a7 and also disables TOC generation on save by the "Markdown All In One" vscode extension.