### PR TITLE
(#221) add a simple codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "75...100"
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 3%
+    patch:
+      default:
+        target: 80%
+        threshold: 3%


### PR DESCRIPTION
This should set the target coverage to 80% and allow each single PR to let coverage drop by 3%.

While this does not sound ideal, the current (default) configuration feels much too fragile, and breaks on too many PRs whose coverage is fine.

fixes #221