### PR TITLE
(#367) Bump GitReleaseManager to 0.18.0

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -23,6 +23,7 @@ BuildParameters.PrintParameters(Context);
 
 ToolSettings.SetToolSettings(context: Context);
 ToolSettings.SetToolPreprocessorDirectives(
+    gitReleaseManagerGlobalTool: "#tool dotnet:?package=GitReleaseManager.Tool&version=0.18.0",
     reSharperTools: "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2022.2.4");
 
 Build.RunDotNetCore();


### PR DESCRIPTION
fixes #367 